### PR TITLE
Potential fix for code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "mongoose": "^8.8.3",
     "multer": "^2.0.1",
     "nodemon": "^2.0.22",
-    "socket.io": "^4.6.1"
+    "socket.io": "^4.6.1",
+    "express-rate-limit": "^8.3.2"
   }
 }

--- a/server/routes/blogRoutes.js
+++ b/server/routes/blogRoutes.js
@@ -1,13 +1,19 @@
 const express = require("express");
 const upload = require("../middlewares/uploadMiddleware");
 const blogController = require("../controllers/blogController");
+const rateLimit = require("express-rate-limit");
 
 const router = express.Router();
+
+const deleteBlogLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 delete requests per windowMs
+});
 
 router.route("/").get(blogController.getAllBlogs);
 router.route("/").post(upload.single("imageFile"), blogController.createBlog);
 router.route("/:id").put(upload.single("imageFile"), blogController.updateBlog);
-router.route("/:id").delete(blogController.deleteBlog);
+router.route("/:id").delete(deleteBlogLimiter, blogController.deleteBlog);
 router.route("/add/:id").put(blogController.addComment);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/Elnur21/coza-store/security/code-scanning/7](https://github.com/Elnur21/coza-store/security/code-scanning/7)

In general, to fix missing rate limiting in an Express route that performs expensive operations, you add a rate-limiting middleware (e.g., `express-rate-limit`) and apply it either globally to the router or specifically to the sensitive routes. This limits the number of requests each client can make over a window, mitigating denial-of-service risks for database and filesystem operations.

For this file, the least invasive and most targeted fix is to import `express-rate-limit`, configure a limiter instance, and attach it specifically to the `DELETE /:id` route (and optionally other write routes if desired). This avoids changing the behavior of unrelated routes while still protecting the expensive handler that CodeQL flagged. Concretely: in `server/routes/blogRoutes.js`, add a `require("express-rate-limit")` near the other imports, create a `RateLimit` limiter (e.g., window of 15 minutes and a maximum number of requests per IP), and then pass that limiter as middleware only on the `router.route("/:id").delete(...)` line. No existing controller logic or ordering needs to change; we simply add one middleware layer.

To implement this, we need: (1) an import line for `express-rate-limit`; (2) a limiter configuration constant defined after the router is created (or nearby the imports); and (3) modification of the delete route to include this limiter in the middleware chain: `router.route("/:id").delete(deleteBlogLimiter, blogController.deleteBlog);`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
